### PR TITLE
increase prefix length for temp files

### DIFF
--- a/src/main/java/biz/neustar/jenkins/plugins/packer/PackerPublisher.java
+++ b/src/main/java/biz/neustar/jenkins/plugins/packer/PackerPublisher.java
@@ -275,7 +275,7 @@ public class PackerPublisher extends Recorder {
 
             for (PackerFileEntry entry : fileEntries.values()) {
                 // should be at least 1 character otherwise that shouldnt be allowed.
-                String prefix = "pp" + entry.getVarFileName();
+                String prefix = "packer-plugin-" + entry.getVarFileName();
                 FilePath entryFile = workspacePath.createTextTempFile(prefix, ".tmp",
                             entry.getContents(), false);
                 variables.append(String.format("-var \"%s=%s\" ", entry.getVarFileName(), entryFile.getRemote()));


### PR DESCRIPTION
This fixes https://github.com/jenkinsci/packer-plugin/issues/9 by increasing the temporary files prefix from 'pp' to 'packer-plugin'. 